### PR TITLE
add a message about circleci setup when not logged in

### DIFF
--- a/hooks/circleci-validate.sh
+++ b/hooks/circleci-validate.sh
@@ -7,4 +7,10 @@ if ! command -v circleci > /dev/null 2>&1; then
   exit 1
 fi
 
+if ! circleci diagnostic > /dev/null 2>&1; then
+  echo "Please ensure you have run 'circleci setup' to login. Run 'circleci diagnostic' to verify connectivity."
+  echo "See https://github.com/CircleCI-Public/circleci-cli#getting-started for instructions."
+  exit 1
+fi
+
 circleci config validate "$@"


### PR DESCRIPTION
Running validation with an org slug, when not logged in ends up in a cryptic error:
```
Error: Unable to validate config: Permission denied
```

Now, when not logged in the following message is displayed:
```
$ ~/src/pre-commit-circleci/hooks/circleci-validate.sh --org-slug github/cerebrotech
Please ensure you have run 'circleci setup' to login. Run 'circleci diagnostic' to verify connectivity.
See https://github.com/CircleCI-Public/circleci-cli#getting-started for instructions.
```